### PR TITLE
fix: pydantic 2.12 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Formatron empowers everyone to control the output format of language models with minimal overhead."
 readme = "README.md"
-dependencies = ["pydantic>=2,<3","kbnf>=0.4.0,<0.5.0", "general-sam>=1,<2", "jsonschema>=4,<5", "frozendict>=2,<3"]
+dependencies = ["pydantic>2.11,<3","kbnf>=0.4.0,<0.5.0", "general-sam>=1,<2", "jsonschema>=4,<5", "frozendict>=2,<3"]
 license = {file = "LICENSE"}
 keywords = ["deep learning", "language model", "guided generation", "structured generation","constrained decoding"]
 requires-python = ">=3.10"

--- a/src/formatron/formats/json.py
+++ b/src/formatron/formats/json.py
@@ -422,6 +422,17 @@ def _register_all_predefined_types():
     register_generate_nonterminal_def(builtin_sequence)
     register_generate_nonterminal_def(builtin_dict)
 
+def _should_cache_nonterminal_identity(current: typing.Any) -> bool:
+    return (
+        isinstance(current, schemas.schema.FieldInfo)
+        or isinstance(current, schemas.schema.TypeWithMetadata)
+        or (
+            isinstance(current, type)
+            and not isinstance(current, types.GenericAlias)
+            and issubclass(current, schemas.schema.Schema)
+        )
+    )
+
 def _generate_kbnf_grammar(schema: schemas.schema.Schema|collections.abc.Sequence, start_nonterminal: str) -> str:
     """
     Generate a KBNF grammar string from a schema for JSON format.
@@ -443,24 +454,39 @@ def _generate_kbnf_grammar(schema: schemas.schema.Schema|collections.abc.Sequenc
         id(dict): "object",
         id(typing.Any): "json_value",
     }
+    active_type_id_to_nonterminal = {}
     result = [GRAMMAR_HEADER]
-    nonterminals = set()
-    stack = [(schema, start_nonterminal)]
+    stack = [("visit", schema, start_nonterminal)]
     while stack:
-        (current, nonterminal) = stack.pop()
+        action, current, nonterminal = stack.pop()
+        if action == "leave":
+            current_id = id(current)
+            type_id_to_nonterminal[current_id] = nonterminal
+            del active_type_id_to_nonterminal[current_id]
+            continue
+
         type_id = id(current)
         if type_id in type_id_to_nonterminal:
             line = f"{nonterminal} ::= {type_id_to_nonterminal[type_id]};\n"
             result.append(line)
             continue
-        type_id_to_nonterminal[type_id] = nonterminal
+        if type_id in active_type_id_to_nonterminal:
+            line = f"{nonterminal} ::= {active_type_id_to_nonterminal[type_id]};\n"
+            result.append(line)
+            continue
+
+        cache_identity = _should_cache_nonterminal_identity(current)
+        if cache_identity:
+            active_type_id_to_nonterminal[type_id] = nonterminal
+
         for i in _type_to_nonterminals:
             value = i(current, nonterminal)
             if value is not None:
                 line, to_stack = value
                 result.append(line)
-                stack.extend(to_stack)
-                nonterminals.add(nonterminal)
+                if cache_identity:
+                    stack.append(("leave", current, nonterminal))
+                stack.extend(("visit", sub_type, sub_nonterminal) for sub_type, sub_nonterminal in to_stack)
                 break
         else:
             raise TypeError(

--- a/src/formatron/schemas/dict_inference.py
+++ b/src/formatron/schemas/dict_inference.py
@@ -3,9 +3,8 @@ This module contains utilities for inferring schemas from dictionaries.
 """
 import collections.abc
 import json
+import typing
 from typing import Any, Type
-
-from pydantic import typing
 
 from formatron import schemas
 
@@ -13,7 +12,7 @@ from formatron import schemas
 class FieldInfo(schemas.schema.FieldInfo):
     __slots__ = ("_annotation",)
 
-    def __init__(self, annotation: typing.Type):
+    def __init__(self, annotation: Type[Any]):
         """
         Initialize the field information.
 
@@ -23,7 +22,7 @@ class FieldInfo(schemas.schema.FieldInfo):
         self._annotation = annotation
 
     @property
-    def annotation(self) -> typing.Type[typing.Any] | None:
+    def annotation(self) -> Type[Any] | None:
         """
         Get the type annotation of the field.
         """
@@ -43,8 +42,8 @@ def _infer_type(value: Any) -> Type[Any]:
     elif isinstance(value, collections.abc.Sequence) and not isinstance(value, str):
         # Handle sequences with possibly heterogeneous elements
         if not value:
-            return collections.Sequence[Any]
-        element_types = set()
+            return collections.abc.Sequence[Any]
+        element_types = []
         for element in value:
             element_type = type(element)
             # Check for dictionary
@@ -53,18 +52,18 @@ def _infer_type(value: Any) -> Type[Any]:
                 original = element_type
             if original is typing.Mapping or isinstance(original, type) and issubclass(original,
                                                                                        collections.abc.Mapping):
-                element_types.add(infer_mapping(element))
-            else:
-                element_types.add(element_type)
+                element_type = infer_mapping(element)
+            if element_type not in element_types:
+                element_types.append(element_type)
         if len(element_types) == 1:
-            return collections.abc.Sequence[next(iter(element_types))]
+            return collections.abc.Sequence[element_types[0]]
         union_type = typing.Union[tuple(element_types)]
         return collections.abc.Sequence[union_type]
     else:
         return type(value)
 
 
-def infer_mapping(mapping: collections.abc.Mapping[str, Any]) -> typing.Type[schemas.schema.Schema]:
+def infer_mapping(mapping: collections.abc.Mapping[str, Any]) -> Type[schemas.schema.Schema]:
     """
     Recursively infer a schema from a mapping.
 

--- a/src/formatron/schemas/json_schema.py
+++ b/src/formatron/schemas/json_schema.py
@@ -6,10 +6,10 @@ import collections
 import collections.abc
 import copy
 import json
+import typing
 from urllib.parse import urldefrag, urljoin
 import frozendict
 import jsonschema.validators
-from pydantic import typing
 import jsonschema
 from formatron import schemas
 from referencing import Registry, Resource
@@ -275,7 +275,7 @@ def _handle_list_metadata(schema: dict[str, typing.Any], json_schema_id_to_schem
     if metadata:
         if "additional_items" not in metadata:
             metadata["additional_items"] = True
-        return schemas.schema.TypeWithMetadata(list, metadata)
+        return schemas.schema.TypeWithMetadata(list[item_type], metadata)
     return list[item_type]
 
 

--- a/src/formatron/schemas/pydantic.py
+++ b/src/formatron/schemas/pydantic.py
@@ -88,34 +88,31 @@ def callable_schema(func: CallableT, /, *, config: ConfigDict = None, validate_r
     signature = inspect.signature(func, eval_str=True)
     fields = {}
     for k, p in signature.parameters.items():
-        default = None
-        if p.default is not inspect.Signature.empty:
-            default = p.default
+        python_default = inspect.Signature.empty
+        if p.default is not inspect.Signature.empty and not isinstance(p.default, pydantic.fields.FieldInfo):
+            python_default = p.default
         actual_type = p.annotation
         metadata = []
+        fieldinfo = None
         if isinstance(p.default, pydantic.fields.FieldInfo):
-            fields[k] = p.default
+            fieldinfo = p.default
         if typing.get_origin(p.annotation) is typing.Annotated:
             actual_type, *meta = typing.get_args(p.annotation)
-            fieldinfo = None
             for i in meta:
                 if isinstance(i, pydantic.fields.FieldInfo):
                     fieldinfo = i
                 else:
                     metadata.append(i)
-            if fieldinfo is not None:
-                fields[k] = fieldinfo
-            if k in fields:
-                fields[k].default = default
-                fields[k].annotation = actual_type
-                fields[k].metadata.extend(metadata)
-                continue
-        if default is not None:
-            fields[k] = Field(default)
-        else:
-            fields[k] = Field()
-        fields[k].annotation = actual_type
-        fields[k].metadata.extend(metadata)
+        if fieldinfo is None:
+            if python_default is not inspect.Signature.empty:
+                fieldinfo = Field(python_default)
+            else:
+                fieldinfo = Field()
+        if python_default is not inspect.Signature.empty:
+            fieldinfo.default = python_default
+        fieldinfo.annotation = actual_type
+        fieldinfo.metadata.extend(metadata)
+        fields[k] = fieldinfo
     for k in fields:
         fields[k] = FieldInfo(fields[k])
 
@@ -123,11 +120,38 @@ def callable_schema(func: CallableT, /, *, config: ConfigDict = None, validate_r
         json_data = json.loads(json_str)
         positional_only = []
         others = {}
+        skipping_positional_only = False
         for k, p in signature.parameters.items():
+            if p.kind == p.VAR_POSITIONAL:
+                if k in json_data:
+                    value = json_data[k]
+                    if not isinstance(value, list):
+                        raise TypeError(f"{k} must be a JSON array")
+                    positional_only.extend(value)
+                continue
+            if p.kind == p.VAR_KEYWORD:
+                if k in json_data:
+                    value = json_data[k]
+                    if not isinstance(value, dict):
+                        raise TypeError(f"{k} must be a JSON object")
+                    others.update(value)
+                continue
+            required = fields[k].required
             if p.kind == p.POSITIONAL_ONLY:
-                positional_only.append(json_data[k])
+                if k in json_data:
+                    if skipping_positional_only:
+                        raise ValueError(f"cannot specify {k} without earlier positional-only parameters")
+                    positional_only.append(json_data[k])
+                else:
+                    if required:
+                        raise KeyError(k)
+                    skipping_positional_only = True
             else:
-                others[k] = json_data[k]
+                if k in json_data:
+                    others[k] = json_data[k]
+                else:
+                    if required:
+                        raise KeyError(k)
         return cls(*positional_only, **others)
 
     _class = type(

--- a/tests/assets/RWKV-5-World-0.4B-v2-20231113-ctx4096.pth
+++ b/tests/assets/RWKV-5-World-0.4B-v2-20231113-ctx4096.pth
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a288c54c7f30b0e2d4af23991133fad2af2d5e59ec7ad850ffe78054a5e4f92
-size 923523954

--- a/tests/test_grammar_gen.py
+++ b/tests/test_grammar_gen.py
@@ -306,6 +306,39 @@ def test_json_schema(snapshot):
     result = JsonExtractor("start", None,schema,lambda x:x).kbnf_definition
     snapshot.assert_match(result)
 
+def test_repeated_union_uses_field_local_nonterminals():
+    repeated_union = typing.Union[str, float]
+
+    class RepeatedUnionSchema(formatron.schemas.pydantic.ClassSchema):
+        name: repeated_union
+        tags: list[repeated_union]
+
+    result = JsonExtractor("start", None, RepeatedUnionSchema, lambda x: x).kbnf_definition
+
+    assert "start_name ::= start_name_0 | start_name_1;\n" in result
+    assert "start_name ::= start_tags_value;\n" not in result
+
+def test_json_schema_repeated_union_uses_field_local_nonterminals():
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://example.com/random-schema.json",
+        "type": "object",
+        "properties": {
+            "name": {"type": ["string", "number"]},
+            "tags": {
+                "type": "array",
+                "items": {"type": ["string", "number"]},
+                "minItems": 1,
+            },
+        },
+        "required": ["name"],
+    }
+
+    result = JsonExtractor("start", None, json_schema.create_schema(schema), lambda x: x).kbnf_definition
+
+    assert "start_name ::= start_name_0 | start_name_1;\n" in result
+    assert "start_name ::= start_tags_required_item;\n" not in result
+
 def test_recursive_binary_tree_schema(snapshot):
     binary_tree_schema = {
         "$id": "https://example.com/binary-tree.json",

--- a/tests/test_pydantic_compat.py
+++ b/tests/test_pydantic_compat.py
@@ -1,0 +1,78 @@
+import collections.abc
+import typing
+
+import formatron.schemas.pydantic
+from formatron.formatter import FormatterBuilder
+from formatron.schemas.dict_inference import infer_mapping
+from formatron.schemas.json_schema import create_schema
+from formatron.schemas.schema import Schema
+
+
+def test_formatter_import_smoke():
+    formatter = FormatterBuilder()
+    assert formatter is not None
+
+
+def test_infer_mapping():
+    schema_type = infer_mapping({"value": [1, "two"]})
+
+    assert issubclass(schema_type, Schema)
+    assert "value" in schema_type.fields()
+
+
+def test_infer_mapping_empty_sequence():
+    schema_type = infer_mapping({"value": []})
+    annotation = schema_type.fields()["value"].annotation
+
+    assert typing.get_origin(annotation) is collections.abc.Sequence
+    assert typing.get_args(annotation) == (typing.Any,)
+
+
+def test_infer_mapping_heterogeneous_sequence_preserves_order():
+    schema_type = infer_mapping({"value": [1, "two", True]})
+    annotation = schema_type.fields()["value"].annotation
+    union_type = typing.get_args(annotation)[0]
+
+    assert typing.get_origin(annotation) is collections.abc.Sequence
+    assert typing.get_origin(union_type) is typing.Union
+    assert typing.get_args(union_type) == (int, str, bool)
+
+
+def test_array_metadata_preserves_item_type():
+    schema_type = create_schema(
+        {
+            "$id": "https://example.com/array-metadata-preserves-item-type.json",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "names": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                }
+            },
+            "required": ["names"],
+        }
+    )
+    annotation = schema_type.fields()["names"].annotation
+
+    assert typing.get_origin(annotation.type) is list
+    assert typing.get_args(annotation.type) == (str,)
+    assert annotation.metadata["min_length"] == 1
+
+
+def test_callable_schema_default_none():
+    @formatron.schemas.pydantic.callable_schema
+    def f(*, x: int | None = None):
+        return x
+
+    assert f.fields()["x"].required is False
+    assert f.from_json("{}") is None
+
+
+def test_callable_schema_from_json_defaults():
+    @formatron.schemas.pydantic.callable_schema
+    def add(a: int, b: int = 2, /, *, c: int = 3):
+        return a + b + c
+
+    assert add.from_json('{"a": 1}') == 6


### PR DESCRIPTION
This fixes the broken pydantic>=2.12 pydantic typing that was caused by an obsolete pydantic-specific typing import. It does not yet guarantee full python 3.14 compatibility. It's only a minimal hotfix for pydantic.

This closes #35.